### PR TITLE
04_fine_tuningのhands_on消し忘れ箇所を修正

### DIFF
--- a/hands-on/04_fine_tuning/04_fine_tuning.ipynb
+++ b/hands-on/04_fine_tuning/04_fine_tuning.ipynb
@@ -253,7 +253,7 @@
     "    directory=___,\n",
     "    validation_split=0.2,\n",
     "    subset=___,\n",
-    "    label_mode='categorical',\n",
+    "    label_mode=___,\n",
     "    seed=1111,\n",
     "    image_size=image_size,\n",
     "    batch_size=batch_size,\n",


### PR DESCRIPTION
fine_tuningのhands_onの<todo>としているlabel_mode部分、両方消す必要があるところを片方しか消していなかったので修正しました:dogeza: